### PR TITLE
Extension now remembers tint colour.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .*\.swp
 .*\.swo
 .*\.swn
+.idea*
+settings.json

--- a/extension.js
+++ b/extension.js
@@ -9,29 +9,62 @@ const PanelMenu = imports.ui.panelMenu;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const IndicatorButton = Extension.imports.indicator_button;
 
+const Gio = imports.gi.Gio;
+
+const ExtensionSystem = imports.ui.extensionSystem;
+
+const ShellVersion = imports.misc.config.PACKAGE_VERSION.split('.');
+let ExtensionPath;
+if (ShellVersion[1] === 2) {
+    ExtensionPath = ExtensionSystem.extensionMeta['panelSettings@eddiefullmetal.gr'].path;
+} else {
+    ExtensionPath = imports.misc.extensionUtils.getCurrentExtension().path;
+}
+
+
 let button;
 let extension = null;
 
 let overlay;
 let overlayOn = false;
 
+var colors = {
+    red: 20,
+    green: 20,
+    blue: 20,
+    alpha: 20,
+
+};
+
 const DesktopTintExtension = new Lang.Class({
     Name: 'DesktopTintExtension',
 
     createOverlay: function() {
+        global.log("createoverlay");
         let monitor = Main.layoutManager.primaryMonitor;
         overlay = new St.Bin({ reactive: false, x_fill: true, y_fill: true });
 
         overlay.set_size(monitor.width, monitor.height);
 
+// Load last from json
 
+       this._file = Gio.file_new_for_path(ExtensionPath + '/settings.json');
+        if(this._file.query_exists(null)) {
+            [flag, data] = this._file.load_contents(null);
+
+            if(flag){
+                colors = JSON.parse(data);
+            }
+        }
+        global.log("Setting clutter color")
         var color = new Clutter.Color(
                 {
-                    red: 255,
-                    green: 100,
-                    blue: 0,
-                    alpha: 120
+                    red: colors["red"],
+                    green: colors["green"],
+                    blue: colors["blue"],
+                    alpha: colors["alpha"]
                 });
+        global.log("clutter color set ")
         overlay.set_background_color(color);
 
         overlay.opacity = 255;
@@ -41,9 +74,11 @@ const DesktopTintExtension = new Lang.Class({
         // Arbitrary z position above everything else
         overlay.set_z_position(650);
 
+
     },
 
     setOverlayColor: function(red, green, blue, alpha) {
+        global.log("setoverlaycolor");
         var color = new Clutter.Color(
                 {
                     red: red,
@@ -55,24 +90,29 @@ const DesktopTintExtension = new Lang.Class({
     },
 
     toggleOverlay: function(actor, event) {
+
         if (overlayOn) {
             Main.uiGroup.remove_actor(overlay);
             overlayOn = false;
+
         } else {
             Main.uiGroup.add_actor(overlay);
             overlayOn = true;
         }
+
     },
 
     enable: function() {
+
         this.createOverlay();
         Main.uiGroup.add_actor(overlay);
         overlayOn = true;
-        this.indicator = new IndicatorButton.IndicatorButton(this.toggleOverlay, this.setOverlayColor, overlay);
+        this.indicator = new IndicatorButton.IndicatorButton(this.toggleOverlay, this.setOverlayColor, colors, overlay);
         Main.panel.addToStatusArea("ChatStatus", this.indicator, 0, "right");
     },
 
     disable: function() {
+
         Main.uiGroup.remove_actor(overlay);
         overlay = null;
         overlayOn = false;

--- a/indicator_button.js
+++ b/indicator_button.js
@@ -6,12 +6,25 @@ const Shell = imports.gi.Shell;
 const Clutter = imports.gi.Clutter;
 const Signals = imports.signals;
 const Slider = imports.ui.slider;
+const Gio = imports.gi.Gio;
 
+const ExtensionSystem = imports.ui.extensionSystem;
+
+const ShellVersion = imports.misc.config.PACKAGE_VERSION.split('.');
+let ExtensionPath;
+if (ShellVersion[1] === 2) {
+    ExtensionPath = ExtensionSystem.extensionMeta['panelSettings@eddiefullmetal.gr'].path;
+} else {
+    ExtensionPath = imports.misc.extensionUtils.getCurrentExtension().path;
+}
 const IndicatorButton = new Lang.Class({
     Name: "IndicatorButton",
     Extends: PanelMenu.Button,
 
-    _init: function(overlayToggle, setOverlayColor) {
+
+
+    _init: function(overlayToggle, setOverlayColor, colors) {
+        this.colors=colors;
         this.parent(St.Align.START, _("Desktop Tint"), false);
 
         this._setOverlayColor = setOverlayColor;
@@ -30,9 +43,11 @@ const IndicatorButton = new Lang.Class({
         this.actor.add_actor(this.hbox);
 
         this._createMenu();
+        this._updateOverlay();
     },
 
     _createMenu: function() {
+        colors = this.colors;
         this._displayToggle = new PopupMenu.PopupSwitchMenuItem("Tint", true);
         this._displayToggle.connect('toggled', Lang.bind(this,
                     function() {
@@ -41,7 +56,7 @@ const IndicatorButton = new Lang.Class({
         this.menu.addMenuItem(this._displayToggle);
 
         // Red
-        this._redSlider = new Slider.Slider(1);
+        this._redSlider = new Slider.Slider(colors["red"] / 255);
         this._redSlider.connect('value-changed', Lang.bind(this,this._updateOverlay));
         let _redLabel = new St.Label({text: "Red  "});
         this._redSliderContainer = new PopupMenu.PopupBaseMenuItem({activate: false});
@@ -50,7 +65,7 @@ const IndicatorButton = new Lang.Class({
         this.menu.addMenuItem(this._redSliderContainer);
 
         // green
-        this._greenSlider = new Slider.Slider(0.4);
+        this._greenSlider = new Slider.Slider(colors["green"] / 255);
         this._greenSlider.connect('value-changed', Lang.bind(this,this._updateOverlay));
         let _greenLabel = new St.Label({text: "Green"});
         this._greenSliderContainer = new PopupMenu.PopupBaseMenuItem({activate: false});
@@ -59,16 +74,17 @@ const IndicatorButton = new Lang.Class({
         this.menu.addMenuItem(this._greenSliderContainer);
 
         // blue
-        this._blueSlider = new Slider.Slider(0);
+        global.log("Setting slider blue");
+        this._blueSlider = new Slider.Slider(colors["blue"] / 255);
         this._blueSlider.connect('value-changed', Lang.bind(this,this._updateOverlay));
         let _blueLabel = new St.Label({text: "Blue "});
         this._blueSliderContainer = new PopupMenu.PopupBaseMenuItem({activate: false});
         this._blueSliderContainer.actor.add(_blueLabel);
         this._blueSliderContainer.actor.add(this._blueSlider.actor, {expand: true});
         this.menu.addMenuItem(this._blueSliderContainer);
-
+        global.log("slider blue set");
         // alpha
-        this._alphaSlider = new Slider.Slider(0.5);
+        this._alphaSlider = new Slider.Slider(colors["alpha"] / 255);
         this._alphaSlider.connect('value-changed', Lang.bind(this,this._updateOverlay));
         let _alphaLabel = new St.Label({text: "Alpha"});
         this._alphaSliderContainer = new PopupMenu.PopupBaseMenuItem({activate: false});
@@ -76,13 +92,29 @@ const IndicatorButton = new Lang.Class({
         this._alphaSliderContainer.actor.add(this._alphaSlider.actor, {expand: true});
         this.menu.addMenuItem(this._alphaSliderContainer);
 
-        this._updateOverlay();
+
     },
 
     _updateOverlay: function () {
-        this._setOverlayColor(255 * this._redSlider._getCurrentValue(),
-                255 * this._greenSlider._getCurrentValue(),
-                255 * this._blueSlider._getCurrentValue(),
-                255 * this._alphaSlider._getCurrentValue());
+        colors = this.colors;
+        colors["red"] = 255 * this._redSlider._getCurrentValue();
+        colors["green"] = 255 * this._greenSlider._getCurrentValue();
+        colors["blue"] = 255 * this._blueSlider._getCurrentValue();
+        colors["alpha"] = 255 * this._alphaSlider._getCurrentValue();
+
+
+        this._setOverlayColor(colors["red"],
+            colors["green"],
+                colors["blue"],
+                colors["alpha"]);
+
+
+
+        // save as json
+
+
+
+       this._file = Gio.file_new_for_path(ExtensionPath + '/settings.json');
+       this._file.replace_contents(JSON.stringify(colors), null, false, 0, null);
     }
 });


### PR DESCRIPTION
Very basic, probably needs refactoring, but it works for me. Colours and alpha now stored in 'settings.json' on change, and when the extension starts, these settings are read.

 Changes to be committed:
	modified:   .gitignore
	modified:   extension.js
	modified:   indicator_button.js